### PR TITLE
Change URL to point directly to files on framabag.org

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = wallabag
 	pkgdesc = Self hostable application for saving web pages
-	pkgver = 2.1.3
+	pkgver = 2.1.4
 	pkgrel = 1
 	url = http://www.wallabag.org/
 	install = wallabag.install
@@ -19,8 +19,8 @@ pkgbase = wallabag
 	backup = usr/share/webapps/wallabag/parameters.yml
 	backup = var/lib/wallabag/data/db/wallabag.sqlite
 	backup = usr/share/webapps/wallabag/data/db/wallabag.sqlite
-	source = wallabag.tar.xz::http://wllbg.org/latest-v2-package
-	sha256sums = f72d6e8dfd7975c4f407e5d531c52b865b3e2a72d755798ac908dcfc22d6815e
+	source = https://framabag.org/wallabag-release-2.1.4.tar.gz
+	sha256sums = eb64205a4d7c161527edd08bed22e8dd9799fe8a4130c5964c18cba3a94c9768
 
 pkgname = wallabag
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp Schmitt (philipp<at>schmitt<dot>co)
 
 pkgname=wallabag
-pkgver=2.1.3
+pkgver=2.1.4
 pkgrel=1
 pkgdesc='Self hostable application for saving web pages'
 arch=('any')
@@ -21,8 +21,9 @@ optdepends=(
 )
 install="$pkgname.install"
 options=(!strip)
-source=("${pkgname}.tar.xz::http://wllbg.org/latest-v2-package")
-sha256sums=('f72d6e8dfd7975c4f407e5d531c52b865b3e2a72d755798ac908dcfc22d6815e')
+source=("https://framabag.org/wallabag-release-${pkgver}.tar.gz")
+#source=("${pkgname}-release-${pkgver}.tar.gz::http://wllbg.org/latest-v2-package") # you may try this URL, if the above one is not available
+sha256sums=('eb64205a4d7c161527edd08bed22e8dd9799fe8a4130c5964c18cba3a94c9768')
 backup=("etc/webapps/${pkgname}/parameters.yml"
         "usr/share/webapps/${pkgname}/parameters.yml"
         "var/lib/${pkgname}/data/db/wallabag.sqlite"


### PR DESCRIPTION
This will prevent the package to "break" as soon as a new version is released (because of the checksum mismatch).

`http://wllbg.org/latest-v2-package` redirects to the latest release file on `framabag.org` (currently `http://framabag.org/wallabag-release-2.1.4.tar.gz`).
I asked about files location and one of the wallabag devs answered on gitter:
> They are at http://framabag.org/wallabag-release-2.x.x.tar.gz but it's dirty, they will probably move in the future.

I added a comment with the old URL `http://wllbg.org/latest-v2-package` in case the direct one breaks.

Also updated the package to 2.1.4.