### PR TITLE
Update to 2.1.5

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = wallabag
 	pkgdesc = Self hostable application for saving web pages
-	pkgver = 2.1.5
+	pkgver = 2.1.6
 	pkgrel = 1
 	url = http://www.wallabag.org/
 	install = wallabag.install
@@ -19,8 +19,8 @@ pkgbase = wallabag
 	backup = usr/share/webapps/wallabag/parameters.yml
 	backup = var/lib/wallabag/data/db/wallabag.sqlite
 	backup = usr/share/webapps/wallabag/data/db/wallabag.sqlite
-	source = https://static.wallabag.org/releases/wallabag-release-2.1.5.tar.gz
-	sha256sums = d212137930fcf4458664ac2d35421db719acd4ee0300f45e972b23e478190ff4
+	source = https://static.wallabag.org/releases/wallabag-release-2.1.6.tar.gz
+	sha256sums = dd9daaba82a367c06cd62e7b55132830d70725136af9361d53b0572af3e4de7e
 
 pkgname = wallabag
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = wallabag
 	pkgdesc = Self hostable application for saving web pages
-	pkgver = 2.1.4
+	pkgver = 2.1.5
 	pkgrel = 1
 	url = http://www.wallabag.org/
 	install = wallabag.install
 	arch = any
 	license = MIT
-	depends = php>=5.3.3
+	depends = php>=5.5
 	depends = php-gd
 	depends = php-tidy
 	depends = pcre
@@ -19,8 +19,8 @@ pkgbase = wallabag
 	backup = usr/share/webapps/wallabag/parameters.yml
 	backup = var/lib/wallabag/data/db/wallabag.sqlite
 	backup = usr/share/webapps/wallabag/data/db/wallabag.sqlite
-	source = https://framabag.org/wallabag-release-2.1.4.tar.gz
-	sha256sums = eb64205a4d7c161527edd08bed22e8dd9799fe8a4130c5964c18cba3a94c9768
+	source = https://static.wallabag.org/releases/wallabag-release-2.1.5.tar.gz
+	sha256sums = d212137930fcf4458664ac2d35421db719acd4ee0300f45e972b23e478190ff4
 
 pkgname = wallabag
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Philipp Schmitt (philipp<at>schmitt<dot>co)
 
 pkgname=wallabag
-pkgver=2.1.4
+pkgver=2.1.5
 pkgrel=1
 pkgdesc='Self hostable application for saving web pages'
 arch=('any')
 url='http://www.wallabag.org/'
 license=('MIT')
 depends=(
-    'php>=5.3.3'
+    'php>=5.5'
     'php-gd'
     'php-tidy'
     'pcre'
@@ -21,9 +21,8 @@ optdepends=(
 )
 install="$pkgname.install"
 options=(!strip)
-source=("https://framabag.org/wallabag-release-${pkgver}.tar.gz")
-#source=("${pkgname}-release-${pkgver}.tar.gz::http://wllbg.org/latest-v2-package") # you may try this URL, if the above one is not available
-sha256sums=('eb64205a4d7c161527edd08bed22e8dd9799fe8a4130c5964c18cba3a94c9768')
+source=("https://static.wallabag.org/releases/wallabag-release-${pkgver}.tar.gz")
+sha256sums=('d212137930fcf4458664ac2d35421db719acd4ee0300f45e972b23e478190ff4')
 backup=("etc/webapps/${pkgname}/parameters.yml"
         "usr/share/webapps/${pkgname}/parameters.yml"
         "var/lib/${pkgname}/data/db/wallabag.sqlite"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -41,9 +41,11 @@ package() {
     ln -s /etc/webapps/${pkgname}/parameters.yml "${WALLABAG_CONF_DIR}"/
 
     _VAR_DIR="${pkgdir}/var/lib/${pkgname}/"
-    install -d "$_VAR_DIR"
-    mv "${pkgdir}/usr/share/webapps/${pkgname}/"{data,var} "$_VAR_DIR"
-    ln -s "/var/lib/${pkgname}/"{data,var} "${pkgdir}/usr/share/webapps/${pkgname}/"
+    install -d "$_VAR_DIR"{,var}
+    install -d "$_VAR_DIR/var/"{cache,logs,sessions}
+    mv "${pkgdir}/usr/share/webapps/${pkgname}/data" "$_VAR_DIR"
+    ln -s "/var/lib/${pkgname}/data" "${pkgdir}/usr/share/webapps/${pkgname}/"
+    ln -s "/var/lib/${pkgname}/var/"{cache,logs,sessions} "${pkgdir}/usr/share/webapps/${pkgname}/var/"
     chown -R http:http "$_VAR_DIR"
 
     chown -R http:http "${pkgdir}/usr/share/webapps/${pkgname}"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp Schmitt (philipp<at>schmitt<dot>co)
 
 pkgname=wallabag
-pkgver=2.1.5
+pkgver=2.1.6
 pkgrel=1
 pkgdesc='Self hostable application for saving web pages'
 arch=('any')
@@ -22,7 +22,7 @@ optdepends=(
 install="$pkgname.install"
 options=(!strip)
 source=("https://static.wallabag.org/releases/wallabag-release-${pkgver}.tar.gz")
-sha256sums=('d212137930fcf4458664ac2d35421db719acd4ee0300f45e972b23e478190ff4')
+sha256sums=('dd9daaba82a367c06cd62e7b55132830d70725136af9361d53b0572af3e4de7e')
 backup=("etc/webapps/${pkgname}/parameters.yml"
         "usr/share/webapps/${pkgname}/parameters.yml"
         "var/lib/${pkgname}/data/db/wallabag.sqlite"

--- a/wallabag.install
+++ b/wallabag.install
@@ -25,14 +25,12 @@ pre_upgrade() {
             /usr/share/webapps/wallabag/app/config/parameters.yml \
             -t /etc/webapps/wallabag/
     fi
-    # also move `data` and `var` to /var/lib/wallabag/
+    # move `data` to /var/lib/wallabag/
     if [[ -d /usr/share/webapps/wallabag/data && \
-          ! -h /usr/share/webapps/wallabag/data && \
-           -d /usr/share/webapps/wallabag/var && \
-          ! -h /usr/share/webapps/wallabag/var ]]; then
+          ! -h /usr/share/webapps/wallabag/data ]]; then
         install -d /var/lib/wallabag/
         chown http:http /var/lib/wallabag/
-        mv /usr/share/webapps/wallabag/{data,var} /var/lib/wallabag/
+        mv /usr/share/webapps/wallabag/data /var/lib/wallabag/data
     fi
 }
 


### PR DESCRIPTION
2.1.5 update is minor ([only compatibility with PHP 5.5](https://www.wallabag.org/blog/2016/11/21/wallabag-215)), so there is no hurry.

I started to update the package to 2.1.5, but with this version it became clear that `bootstrap.php.cache` in `var` should not be moved to `/var/lib/`, so I reorganized it a bit.
Also, the release archives are available from a new stable URL, thanks to wallabag team.

**I have not updated `wallabag.install` yet**, I hope to get back to it soon.