### PR TITLE
Update to 2.3.5

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp Schmitt (philipp<at>schmitt<dot>co)
 
 pkgname=wallabag
-pkgver=2.3.3
+pkgver=2.3.5
 pkgrel=1
 pkgdesc='Self hostable application for saving web pages'
 arch=('any')
@@ -22,7 +22,7 @@ optdepends=(
 install="$pkgname.install"
 options=(!strip)
 source=("https://static.wallabag.org/releases/wallabag-release-${pkgver}.tar.gz")
-sha256sums=('eff21708f49f5d3d28dc51a34a5de63e551c1062ea3b7fd3c59d58fca26a058b')
+sha256sums=('1b506a5050ccd9319833d16cebb1b0ed354445e03de991f0eb130c40a92f94e6')
 backup=("etc/webapps/${pkgname}/parameters.yml"
         "usr/share/webapps/${pkgname}/parameters.yml"
         "var/lib/${pkgname}/data/db/wallabag.sqlite"


### PR DESCRIPTION
Wallabag has been updated to [2.3.4](https://github.com/wallabag/wallabag/releases/tag/2.3.4) and to [2.3.5](https://github.com/wallabag/wallabag/releases/tag/2.3.5).

I simply changed `pkgver` and `sha256sums` and did not encounter any issues so far. 